### PR TITLE
Add support for loading schemas in WildFly

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject democracyworks.datomic-toolbox "0.2.6-SNAPSHOT"
+(defproject democracyworks/datomic-toolbox "1.0.0-SNAPSHOT"
   :description "Datomic utilities"
   :url "http://github.com/democracyworks/datomic-toolbox"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.datomic/datomic-pro "0.9.5130"]
+                 [com.datomic/datomic-pro "0.9.5153"]
                  [turbovote.resource-config "0.1.4"]]
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
                                    :username [:gpg :env]

--- a/src/datomic_toolbox.clj
+++ b/src/datomic_toolbox.clj
@@ -1,4 +1,4 @@
-(ns turbovote.datomic-toolbox
+(ns datomic-toolbox
   (:require [clojure.java.io :as io]
             [clojure.walk :as walk]
             [datomic.api :as d]

--- a/src/datomic_toolbox.clj
+++ b/src/datomic_toolbox.clj
@@ -40,11 +40,18 @@
        (filter #(.startsWith (str %) "schemas/"))
        (map (comp io/resource str))))
 
+(defn vfs-schemas [resource]
+  (->> resource
+       .getContent
+       .getChildren
+       (map #(.getPhysicalFile %))))
+
 (defn schema-files []
   (let [resource (io/resource "schemas")
-        files (if (= "jar" (.getProtocol resource))
-                (jarred-schemas resource)
-                (-> resource io/as-file file-seq))]
+        files    (condp = (.getProtocol resource)
+                   "jar" (jarred-schemas resource)
+                   "vfs" (vfs-schemas resource)
+                   (-> resource io/as-file file-seq))]
     (->> files
          (filter #(.endsWith (resource-name %) ".edn"))
          (sort-by #(resource-name %)))))

--- a/test/datomic_toolbox_test.clj
+++ b/test/datomic_toolbox_test.clj
@@ -1,6 +1,6 @@
-(ns turbovote.datomic-toolbox-test
+(ns datomic-toolbox-test
   (:require [clojure.test :refer :all]
-            [turbovote.datomic-toolbox :refer :all]
+            [datomic-toolbox :refer :all]
             [turbovote.resource-config :refer [config]]
             [datomic.api :as d])
   (:refer-clojure :exclude [partition]))

--- a/test/migration_test.clj
+++ b/test/migration_test.clj
@@ -1,6 +1,6 @@
-(ns turbovote.migration-test
+(ns migration-test
   (:require [clojure.test :refer :all]
-            [turbovote.datomic-toolbox :refer :all]
+            [datomic-toolbox :refer :all]
             [turbovote.resource-config :refer [config]]
             [datomic.api :as d])
   (:refer-clojure :exclude [partition]))


### PR DESCRIPTION
Since I was touching this library, I took the opportunity to migrate it to our new preferred naming convention (it's closer to the way they recommend naming libraries).

WildFly uses vfs protocol resources, so this is primarily intended to add support for loading schema files via that protocol.

I bumped the version to 1.0.0-SNAPSHOT since the rename is a breaking change.

Assigning @tie-rack.

No card because it's Friday! But actually it is needed to support deploying datomic-toolbox-using apps to WildFly.