### PR TITLE
Misc improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,8 @@
+* Changes between 1.0.0 and HEAD
+    * Added a core namespace. Code using this library will need to update
+    require and use statements to refer to `datomic-toolbox.core`.
+    **This is a breaking change.**
+    * Updated to Clojure 1.7.0.
+    * Updated to turbovote.resource-config 0.2.0. If you use both this and
+    resource-config, **then this is a breaking change for you.** You will
+    need to update to resource-config 0.2.0+ as well.

--- a/README.md
+++ b/README.md
@@ -17,4 +17,7 @@ There is currently no support for automatic migration running other than when `(
 
 ## License
 
-Copyright © 2014 Democracy Works, Inc.
+Copyright © 2014-2015 Democracy Works, Inc.
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/democracyworks/datomic-toolbox"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [com.datomic/datomic-pro "0.9.5153"]
                  [turbovote.resource-config "0.2.0"]]
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.datomic/datomic-pro "0.9.5153"]
-                 [turbovote.resource-config "0.1.4"]]
+                 [turbovote.resource-config "0.2.0"]]
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
                                    :username [:gpg :env]
                                    :password [:gpg :env]}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject democracyworks/datomic-toolbox "1.0.0"
+(defproject democracyworks/datomic-toolbox "1.0.1-SNAPSHOT"
   :description "Datomic utilities"
   :url "http://github.com/democracyworks/datomic-toolbox"
   :license {:name "Eclipse Public License"

--- a/src/datomic_toolbox/core.clj
+++ b/src/datomic_toolbox/core.clj
@@ -1,4 +1,4 @@
-(ns datomic-toolbox
+(ns datomic-toolbox.core
   (:require [clojure.java.io :as io]
             [clojure.walk :as walk]
             [datomic.api :as d]

--- a/src/datomic_toolbox/core.clj
+++ b/src/datomic_toolbox/core.clj
@@ -6,14 +6,14 @@
   (:refer-clojure :exclude [partition]))
 
 (defn connection []
-  (d/connect (config :datomic :uri)))
+  (d/connect (config [:datomic :uri])))
 
 (def db (comp d/db connection))
 
 (defn transact [tx-data]
   (d/transact (connection) tx-data))
 
-(defn partition [] (config :datomic :partition))
+(defn partition [] (config [:datomic :partition]))
 
 (defprotocol INamedResource
   (resource-name [resource]))
@@ -96,7 +96,7 @@
       deref))
 
 (defn initialize []
-  (d/create-database (config :datomic :uri))
+  (d/create-database (config [:datomic :uri]))
   (install-migration-schema)
   (run-migrations))
 

--- a/test/datomic_toolbox/core_test.clj
+++ b/test/datomic_toolbox/core_test.clj
@@ -7,7 +7,7 @@
 
 (defn recreate-db
   [f]
-  (d/delete-database (config :datomic :uri))
+  (d/delete-database (config [:datomic :uri]))
   (initialize)
   (f))
 

--- a/test/datomic_toolbox/core_test.clj
+++ b/test/datomic_toolbox/core_test.clj
@@ -1,6 +1,6 @@
-(ns datomic-toolbox-test
+(ns datomic-toolbox.core-test
   (:require [clojure.test :refer :all]
-            [datomic-toolbox :refer :all]
+            [datomic-toolbox.core :refer :all]
             [turbovote.resource-config :refer [config]]
             [datomic.api :as d])
   (:refer-clojure :exclude [partition]))

--- a/test/datomic_toolbox/migration_test.clj
+++ b/test/datomic_toolbox/migration_test.clj
@@ -6,8 +6,8 @@
   (:refer-clojure :exclude [partition]))
 
 (defn migration-ready-db [f]
-  (d/delete-database (config :datomic :uri))
-  (d/create-database (config :datomic :uri))
+  (d/delete-database (config [:datomic :uri]))
+  (d/create-database (config [:datomic :uri]))
   (install-migration-schema)
   (f))
 

--- a/test/datomic_toolbox/migration_test.clj
+++ b/test/datomic_toolbox/migration_test.clj
@@ -1,6 +1,6 @@
-(ns migration-test
+(ns datomic-toolbox.migration-test
   (:require [clojure.test :refer :all]
-            [datomic-toolbox :refer :all]
+            [datomic-toolbox.core :refer :all]
             [turbovote.resource-config :refer [config]]
             [datomic.api :as d])
   (:refer-clojure :exclude [partition]))


### PR DESCRIPTION
You can't upgrade projects that use resource-config to 0.2.0 until this supports it too (and you upgrade the other projects to the newer version of this library as well).

While I was in there I also added a core namespace so we don't have a single-level namespace here and I updated the version of clojure it uses to 1.7.0.

Since these are breaking changes I also added a Changes.md file and noted that in there.