### PR TITLE
Decouple from resource-config

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.datomic/datomic-pro "0.9.5153"]
-                 [turbovote.resource-config "0.2.0"]]
+                 [com.datomic/datomic-pro "0.9.5153"]]
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
                                    :username [:gpg :env]
                                    :password [:gpg :env]}}

--- a/src/datomic_toolbox/core.clj
+++ b/src/datomic_toolbox/core.clj
@@ -95,7 +95,7 @@
 (defn run-migrations
   ([] (run-migrations (connection) (db)))
   ([connection db] (doseq [file (unapplied-migrations db)]
-                     (run-migration file connection))))
+                     (run-migration connection file))))
 
 (defn install-migration-schema
   ([] (install-migration-schema (connection)))

--- a/src/datomic_toolbox/core.clj
+++ b/src/datomic_toolbox/core.clj
@@ -5,7 +5,6 @@
   (:refer-clojure :exclude [partition]))
 
 (def default-uri (atom nil))
-(def default-connection (atom nil))
 (def default-partition (atom nil))
 
 (defn configure! [{:keys [uri partition]}]
@@ -15,9 +14,7 @@
 (defn uri [] @default-uri)
 
 (defn connection []
-  (let [conn (d/connect (uri))]
-    (reset! default-connection conn)
-    conn))
+  (d/connect (uri)))
 
 (defn partition [] @default-partition)
 

--- a/src/datomic_toolbox/core.clj
+++ b/src/datomic_toolbox/core.clj
@@ -18,7 +18,7 @@
 
 (defn partition [] @default-partition)
 
-(def db (comp d/db connection))
+(defn db [] (d/db (connection)))
 
 (defn transact [tx-data]
   (d/transact (connection) tx-data))

--- a/test-resources/config.edn
+++ b/test-resources/config.edn
@@ -1,2 +1,0 @@
-{:datomic {:uri "datomic:mem://datomic-toolbox-test"
-           :partition :datomic-toolbox-test-partition}}

--- a/test/datomic_toolbox/core_test.clj
+++ b/test/datomic_toolbox/core_test.clj
@@ -1,14 +1,15 @@
 (ns datomic-toolbox.core-test
   (:require [clojure.test :refer :all]
             [datomic-toolbox.core :refer :all]
-            [turbovote.resource-config :refer [config]]
             [datomic.api :as d])
   (:refer-clojure :exclude [partition]))
 
 (defn recreate-db
   [f]
-  (d/delete-database (config [:datomic :uri]))
-  (initialize)
+  (when-let [old-uri (uri)]
+    (d/delete-database old-uri))
+  (initialize {:uri (str "datomic:mem://datomic-toolbox-test-" (java.util.UUID/randomUUID))
+               :partition :datomic-toolbox-test-partition})
   (f))
 
 (use-fixtures :each recreate-db)

--- a/test/datomic_toolbox/migration_test.clj
+++ b/test/datomic_toolbox/migration_test.clj
@@ -1,13 +1,15 @@
 (ns datomic-toolbox.migration-test
   (:require [clojure.test :refer :all]
             [datomic-toolbox.core :refer :all]
-            [turbovote.resource-config :refer [config]]
             [datomic.api :as d])
   (:refer-clojure :exclude [partition]))
 
 (defn migration-ready-db [f]
-  (d/delete-database (config [:datomic :uri]))
-  (d/create-database (config [:datomic :uri]))
+  (when-let [old-uri (uri)]
+    (d/delete-database old-uri))
+  (let [new-uri (str "datomic:mem://datomic-toolbox-test-" (java.util.UUID/randomUUID))]
+    (d/create-database new-uri)
+    (configure! {:uri new-uri :partition "datomic-toolbox-test-partition"}))
   (install-migration-schema)
   (f))
 


### PR DESCRIPTION
This PR is something I made while getting frustrated by my inability to easily use some of datomic-toolbox's features from a REPL that was connected to a different Datomic transactor than was configured in config.edn and my slight annoyance at having to update this library in order to use the latest resource-config version in an app that depended on both of them.

It is intended to start a conversation about how we would like datomic-toolbox and resource-config to interact. As such it goes all the way to the extreme of removing the resource-config dependency entirely, putting all state into atoms, and providing stateless alternatives to all fns that weren't either a) already stateless or b) provided in datomic.api already.

It should be compatible with existing datomic-toolbox consumers with one exception: You must now pass in your Datomic config (which are more than welcome to get from resource-config) into the `datomic-toolbox.core/initialize` function. If you aren't using `initialize` (and really, why wouldn't you? it's idempotent), then you can call the new `datomic-toolbox.core/configure!` fn first instead. Either of these setup the internal Datomic config state so that the stateful fns work the way you're used to.

All the tests still pass.