### PR TITLE
Retry transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ When you need atomic transactions we have `with-retry-tx` that treats Datomic li
      [:db.fn/retractEntity id]]])
 ```
 
-If the value of the `current-mediums` changes mid transaction this code won't throw an exception, rather it will try and run the logic again up to 100 times. This treats Datomic more like an atom.
+If the value of the `current-mediums` changes mid-transaction this
+code won't throw an exception, rather it will try and run the logic
+again up to 100 times. This treats Datomic more like an atom.
 
 ### Transaction Functions
 


### PR DESCRIPTION
Add a function + macro for doing retries when a ConcurrentModificationException happens in datomic.

This function allows us to make atomic updates to a database. Currently, we have many non-atomic updates to the database. You can identify a non-atomic update because it:

* Reads a value from the database at time t0 (does a query, gets an entity)
* Constructs a datomic transaction data structure
* Calls datomic/transact on the data structure at time tn

If anything has modified the database between t0 and tn, this transaction data may be stale, yet still be recorded. For instance:

* Server 1 wants to increment `page-view`. It reads the current `page-view` count at t0, which is 100.
* Server 2 wants to increment `page-view`. It reads the current `page-view` count at t0, which is 100.
* Server 2 is slightly faster, and transacts `(inc page-view)` at t1. Datomic stores `page-view`= 101.
* Server 1 transacts `(inc page-view)` at t2. In its memory, `page-view` is still 100. Datomic stores `page-view` = 101.

After two increments, `page-view` should be 102, but it's 101. This function, along with the database functions defined in #8, will help us make sure everything is counted.

Using this new function and the `:transact` database function, the corrected situation above will look like:

* Server 1 wants to increment `page-view`. It reads the current `page-view` count at t0, which is 100.
* Server 2 wants to increment `page-view`. It reads the current `page-view` count at t0, which is 100.
* Server 2 is slightly faster, and transacts `[:transact userid :page-view 100 101]` at t1. That means "store `page-view`=101 given that it is equal to 100". Datomic stores `page-view`= 101.
* Server 1 transacts `[:transact userid :page-view 100 101]` at t2. This **fails** with a ConcurrentModificationException.
* The retry function catches the exception which starts the Server 1 steps over.
* Server 1  reads the current `page-view` count at t3, which is 101.
* Server 1 transacts `[:transact userid :page-view 101 102]` at t4. Datomic stores `page-view`= 102.

Two increments, and `page-view` is 102, which is correct!

There is an example in [`election-notification-works`][enw-pr].

[enw-pr]: https://github.com/democracyworks/election-notification-works/pull/17