### PR TITLE
Put connection in atom

### DIFF
--- a/src/datomic_toolbox/core.clj
+++ b/src/datomic_toolbox/core.clj
@@ -6,15 +6,24 @@
 
 (def default-uri (atom nil))
 (def default-partition (atom nil))
+(def default-connection
+  "In theory this shouldn't be needed because datomic.api/connect is supposed to
+  cache connections. But we saw 5+ second pauses sometimes when calling this, so
+  I'm trying out storing it an atom instead of re-calling datomic.api/connect.
+  - WSM 2016-2-13"
+  (atom nil))
 
 (defn configure! [{:keys [uri partition]}]
   (reset! default-uri uri)
-  (reset! default-partition partition))
+  (reset! default-partition partition)
+  (reset! default-connection nil))
 
 (defn uri [] @default-uri)
 
 (defn connection []
-  (d/connect (uri)))
+  (when (nil? @default-connection)
+    (reset! default-connection (d/connect (uri))))
+  @default-connection)
 
 (defn partition [] @default-partition)
 

--- a/test/datomic_toolbox/core_test.clj
+++ b/test/datomic_toolbox/core_test.clj
@@ -14,6 +14,12 @@
 
 (use-fixtures :each recreate-db)
 
+(deftest configure!-test
+  (testing "resets connection atom to nil"
+    ;; initialize is implicitly called via the recreate-db fixture
+    (configure! {})
+    (is (nil? @default-connection))))
+
 (deftest initialize-test
   ;; initialize is implicitly called via the recreate-db fixture
   (is (seq (d/q '[:find ?e :where [?e :db/ident :test/name]] (db)))))


### PR DESCRIPTION
It's supposed to be cached so that calling datomic.api/connect
repeatedly is OK. But we were seeing ~5 second pauses sometimes and
traced it down to datomic.api/connect. Putting it into an atom seems to
fix that.

We'll keep working with Cognitect support to figure out what's up, but I
guess there's no reason not to keep doing it this way.