### PR TITLE
Use a fixture so query tests work in isolation

### DIFF
--- a/test/datomic_toolbox/query_test.clj
+++ b/test/datomic_toolbox/query_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.test :refer :all]
             [datomic-toolbox.query :refer :all]
             [datomic.api :as d]
-            [datomic-toolbox.core :as core]))
+            [datomic-toolbox.core :as core]
+            [datomic-toolbox.test-helpers :refer [migrated-test-db]]))
+
+(use-fixtures :each migrated-test-db)
 
 (deftest query-helper-tests
   (let [db (:db-after (d/with (core/db) [{:db/id (core/tempid)


### PR DESCRIPTION
Without the fixture, testing only this namespace with CIDER is sad :(
Using `lein test` coincidentally makes the tests pass.