### PR TITLE
Migration txInstant

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+* Added support for a `:migration-tx-instant` optional config param that can be set to a java.util.Date value.
+  This will be used to set the `:db/txInstant` of the schema migrations when present. Higher arities of the relevant
+  migration functions were also added to facilitate this (but the old ones were kept too so this should _not_ break
+  existing code).
+
 ## Changes between 2.0.1 and 2.0.2
 
 * Updated dependencies, which shouldn't affect users much since you should be

--- a/README.md
+++ b/README.md
@@ -18,13 +18,30 @@ guide (UPGRADING.md) in this repo.
 
 ## Migrations
 
-Datomic Toolbox has support for migrations. The database needs to be initialized by datomic-toolbox to get this support (older databases will need to be migrated). Running `(initialize config-map)` installs the partition and a transaction attribute called :datomic-toolbox/migration, which is used to keep track of which migration files have been run.
+Datomic Toolbox has support for migrations. The database needs to be initialized by datomic-toolbox to get this support
+(older databases will need to be migrated). Running `(initialize config-map)` installs the partition and a transaction 
+attribute called :datomic-toolbox/migration, which is used to keep track of which migration files have been run.
 
-Files in resources/schema that end in .edn are considered migration files. datomic-toolbox orders schema files lexigraphically, so the convention is to name them with a date and time followed by some text describing what they do, e.g. "20140616105400-initial-schema.edn".
+Files in resources/schema that end in .edn are considered migration files. datomic-toolbox orders schema files 
+lexicographically, so the convention is to name them with a date and time followed by some text describing what they do, 
+e.g. "20140616105400-initial-schema.edn".
 
-When `(run-migrations)` is called, it compares the schema files and the :datomic-toolbox/migration transaction attribute to figure out which schema files have not been run, and then runs them in ascending lexigraphical order. When a migration file is run, the transaction is tagged with the migration attribute that contains the name of that schema file. You can use `(applied-migrations)` to get the migration filenames that have been run, and `(unapplied-migrations)` to get the migration files that have not been run.
+When `(run-migrations)` is called, it compares the schema files and the :datomic-toolbox/migration transaction attribute 
+to figure out which schema files have not been run, and then runs them in ascending lexicographical order. When a 
+migration file is run, the transaction is tagged with the migration attribute that contains the name of that schema 
+file. You can use `(applied-migrations)` to get the migration filenames that have been run, and `(unapplied-migrations)`
+to get the migration files that have not been run.
 
-There is currently no support for automatic migration running other than when `(initialize config-map)` is first called, at which time it will run all available migrations. Outside of that, you'll need to make a call to `(run-migrations)` at the appropriate point in your application.
+There is currently no support for automatic migration running other than when `(initialize config-map)` is first called,
+at which time it will run all available migrations. Outside of that, you'll need to make a call to `(run-migrations)` at
+the appropriate point in your application.
+
+### Setting txInstant
+
+When you are importing old data (or simulating data over time in tests, for example), you may need your database basis
+to start at a point sufficiently in the past to give you room to set txInstants in your own transactions. To support
+this Datomic Toolbox allows you to set a `:migration-tx-instant` key to a java.util.Date of your choosing and it will
+then use that as the `:db/txInstant` value on all schema migration transactions it performs.
 
 ## Database functions
 
@@ -147,7 +164,7 @@ database. It also uses `:transact` to assure an atomic transaction.
 
 ## License
 
-Copyright © 2014-2015 Democracy Works, Inc.
+Copyright © 2014-2016 Democracy Works, Inc.
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ guide (UPGRADING.md) in this repo.
 ## Migrations
 
 Datomic Toolbox has support for migrations. The database needs to be initialized by datomic-toolbox to get this support
-(older databases will need to be migrated). Running `(initialize config-map)` installs the partition and a transaction 
+(older databases will need to be migrated). Running `(initialize config-map)` installs the partition and a transaction
 attribute called :datomic-toolbox/migration, which is used to keep track of which migration files have been run.
 
-Files in resources/schema that end in .edn are considered migration files. datomic-toolbox orders schema files 
-lexicographically, so the convention is to name them with a date and time followed by some text describing what they do, 
+Files in resources/schema that end in .edn are considered migration files. datomic-toolbox orders schema files
+lexicographically, so the convention is to name them with a date and time followed by some text describing what they do,
 e.g. "20140616105400-initial-schema.edn".
 
-When `(run-migrations)` is called, it compares the schema files and the :datomic-toolbox/migration transaction attribute 
-to figure out which schema files have not been run, and then runs them in ascending lexicographical order. When a 
-migration file is run, the transaction is tagged with the migration attribute that contains the name of that schema 
+When `(run-migrations)` is called, it compares the schema files and the :datomic-toolbox/migration transaction attribute
+to figure out which schema files have not been run, and then runs them in ascending lexicographical order. When a
+migration file is run, the transaction is tagged with the migration attribute that contains the name of that schema
 file. You can use `(applied-migrations)` to get the migration filenames that have been run, and `(unapplied-migrations)`
 to get the migration files that have not been run.
 
@@ -42,6 +42,12 @@ When you are importing old data (or simulating data over time in tests, for exam
 to start at a point sufficiently in the past to give you room to set txInstants in your own transactions. To support
 this Datomic Toolbox allows you to set a `:migration-tx-instant` key to a java.util.Date of your choosing and it will
 then use that as the `:db/txInstant` value on all schema migration transactions it performs.
+
+**NOTE:** This is intended only for use in ephemeral configurations (import scripts, memory-transactor-based
+tests, etc.) and it will fall down pretty quickly if used outside these narrow use cases. That is because as soon
+as you transact any data without an explicit `:db/txInstant` in the transaction, the datetime you run that
+transaction becomes the new database basis. That means any future transactions that datomic-toolbox
+tries to run with your configured `:migration-tx-instant` will fail.
 
 ## Database functions
 

--- a/src/datomic_toolbox/migration.clj
+++ b/src/datomic_toolbox/migration.clj
@@ -37,7 +37,7 @@
      (doseq [file (unapplied db dir)]
        (run connection file tx-instant)))))
 
-(defn set-tx-instant [tx-data tx-instant]
+(defn set-tx-instant [tx-instant tx-data]
   (if tx-instant
     (conj tx-data
           {:db/id #db/id [:db.part/tx]
@@ -48,15 +48,15 @@
   ([connection partition]
    (install-schema connection partition nil))
   ([connection partition tx-instant]
-   (-> [{:db/id #db/id[:db.part/db]
-         :db/ident partition
-         :db.install/_partition :db.part/db}
-        {:db/id #db/id[:db.part/db]
-         :db/ident :datomic-toolbox/migration
-         :db/valueType :db.type/string
-         :db/cardinality :db.cardinality/one
-         :db/doc "Migration File Name"
-         :db.install/_attribute :db.part/db}]
-       (set-tx-instant tx-instant)
-       (->> (d/transact connection))
-       deref)))
+   (->> [{:db/id #db/id[:db.part/db]
+          :db/ident partition
+          :db.install/_partition :db.part/db}
+         {:db/id #db/id[:db.part/db]
+          :db/ident :datomic-toolbox/migration
+          :db/valueType :db.type/string
+          :db/cardinality :db.cardinality/one
+          :db/doc "Migration File Name"
+          :db.install/_attribute :db.part/db}]
+        (set-tx-instant tx-instant)
+        (d/transact connection)
+        deref)))

--- a/src/datomic_toolbox/transaction.clj
+++ b/src/datomic_toolbox/transaction.clj
@@ -50,8 +50,8 @@
        ~docstring
        ([data-map#] (~name (core/tempid) data-map#))
        ([~id-sym data-map#]
-          (let [{:keys ~params} data-map#]
-            ~@body-with-id)))))
+        (let [{:keys ~params} data-map#]
+          ~@body-with-id)))))
 
 (defn- swap-tx*
   "Helper for swap-tx!"


### PR DESCRIPTION
If you're trying to set historical txInstants in your own data, you need these schema migration transactions to start earlier than all of that (txInstants may only increase monotonically).

We're doing that in some ballot-scout tests of the new "stats by day" API endpoint. [This is the ballot-scout PR for that](https://github.com/democracyworks/ballot-scout/pull/192).