### PR TITLE
Add initialize retries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.datomic/datomic-pro "0.9.5394"]
-                 [com.amazonaws/aws-java-sdk-dynamodb "1.11.6"]]
+                 [com.amazonaws/aws-java-sdk-dynamodb "1.11.6"]
+                 [org.clojure/tools.logging "0.3.1"]]
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
                                    :username [:gpg :env]
                                    :password [:gpg :env]}}

--- a/src/datomic_toolbox/query.clj
+++ b/src/datomic_toolbox/query.clj
@@ -43,16 +43,16 @@
    entity in ascending order.
    Pass in the entity or a database and the entity id."
   ([entity]
-     (timestamps (d/entity-db entity) (:db/id entity)))
+   (timestamps (d/entity-db entity) (:db/id entity)))
   ([db id]
-      (let [tx-instants (->> (d/q '[:find ?txInstant
-                                    :in $ ?e
-                                    :where
-                                    [?e _ _ ?tx]
-                                    [?tx :db/txInstant ?txInstant]]
-                                  (d/history db) id)
-                             (map first)
-                             sort)]
-        {:created-at (first tx-instants)
-         :updated-at (last tx-instants)
-         :timestamps tx-instants})))
+   (let [tx-instants (->> (d/q '[:find ?txInstant
+                                 :in $ ?e
+                                 :where
+                                 [?e _ _ ?tx]
+                                 [?tx :db/txInstant ?txInstant]]
+                               (d/history db) id)
+                          (map first)
+                          sort)]
+     {:created-at (first tx-instants)
+      :updated-at (last tx-instants)
+      :timestamps tx-instants})))

--- a/test/datomic_toolbox/core_test.clj
+++ b/test/datomic_toolbox/core_test.clj
@@ -27,3 +27,14 @@
 (deftest tempid-test
   (let [id (tempid)]
     (is (= (:part id) (partition)))))
+
+(deftest create-database-with-retries-test
+  (testing "retries after exceptions creating the database"
+    (let [attempts (atom 0)]
+      (with-redefs [d/create-database (fn [_]
+                                        (if (< @attempts 3)
+                                          (do (swap! attempts inc)
+                                              (throw
+                                                (Exception. "test exception")))
+                                          true))]
+        (is (create-database-with-retries "fake://uri" 4))))))


### PR DESCRIPTION
An attempt to alleviate the dev environment errors that seemed to be caused by something coming up before Datomic was actually ready for connections.

This was slowing us down a lot, so as soon as I could reproduce it, I wanted to try fixing it.

I am unable to reproduce any Datomic errors in docker-compose stacks using this code.